### PR TITLE
Update favicon URL

### DIFF
--- a/src/components/dock/Dock.tsx
+++ b/src/components/dock/Dock.tsx
@@ -18,7 +18,7 @@ import TodoDialog from "../todo/Todo";
 import "./Dock.css";
 import { AppContext } from "../../context/provider";
 
-const SITE_IMAGE_URL = "https://www.google.com/s2/favicons?sz=64&domain=";
+const SITE_IMAGE_URL = "https://favicone.com/";
 
 const TooltipPosition: Record<string, string> = {
   left: "right",
@@ -236,7 +236,7 @@ const Dock = memo(() => {
               >
                 <img
                   className="dock-site__icon"
-                  src={SITE_IMAGE_URL + siteURL?.hostname}
+                  src={`${SITE_IMAGE_URL}${siteURL?.hostname}?s=32`}
                   alt={item.title}
                 />
               </a>


### PR DESCRIPTION
This pull request updates the favicon URL in the Dock component to use favicone.com, which provides a more reliable and consistent way of fetching favicons.
Changes:
Updated the SITE_IMAGE_URL constant to point to favicone.com
Modified the image src to include the hostname and size parameter (?s=32)
Reasoning:
The previous API was failing to fetch the favicon of few of the top websites such as leetcode.com and web.whatsapp.com etc.