### PR TITLE
fix: resolve timezone issue causing events to render on wrong day

### DIFF
--- a/src/utils/calendar.ts
+++ b/src/utils/calendar.ts
@@ -174,7 +174,9 @@ export function getFormattedDateStringForEventsGroup(
   language: keyof typeof translation = "en"
 ) {
   const locale = languageLocaleMap[language] || "en-US";
-  const date = new Date(dateString);
+  const date = new Date(
+    dateString.includes("T") ? dateString : `${dateString}T00:00:00`
+  );
 
   const weekday = new Intl.DateTimeFormat(locale, { weekday: "long" }).format(
     date
@@ -205,7 +207,9 @@ export function getFormattedTimeString(
 }
 
 export function isToday(dateString: string): boolean {
-  const givenDate = new Date(dateString);
+  const givenDate = new Date(
+    dateString.includes("T") ? dateString : `${dateString}T00:00:00`,
+  );
   const today = new Date();
 
   return (


### PR DESCRIPTION
Fixes #16.

### The Bug
Users in specific timezones (like EST) were seeing today's Google Calendar events showing up under yesterday's date header.

### The Cause
This was caused by how JavaScript handles dates. When the code groups events, it creates strings like `"2024-03-15"`. When these `YYYY-MM-DD` strings are parsed back into a `Date` object to render the UI, JavaScript defaults to treating them as **UTC midnight**. 
When the user's browser converts UTC midnight to a local timezone that is behind UTC (like EST), it subtracts hours, bumping the rendered label back to the previous day.

### The Fix
I updated the `getFormattedDateStringForEventsGroup` and `isToday` helpers in `src/utils/calendar.ts`. By appending `T00:00:00` to the date string before parsing it, we force JavaScript to interpret it in the user's **local timezone** rather than UTC. 
