### PR TITLE
fix: normalize drag coords under zoom

### DIFF
--- a/src/components/focus/FocusMode.tsx
+++ b/src/components/focus/FocusMode.tsx
@@ -4,6 +4,7 @@ import { AppContext } from "../../context/provider";
 import { translation } from "../../locale/languages";
 import { ReactComponent as CloseIcon } from "../settings/close-icon.svg";
 import { ReactComponent as MinimizeIcon } from "../settings/minimize-icon.svg";
+import { getBodyZoomScale } from "../../utils/zoom";
 
 const DEFAULT_DURATION = 25 * 60; // 25 minutes
 
@@ -38,6 +39,7 @@ const FocusMode: React.FC<{
   const [position, setPosition] = useState({ x: 100, y: 100 });
   const [isDragging, setIsDragging] = useState(false);
   const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 });
+  const dragScale = useRef(1);
 
   const audioContextRef = useRef<AudioContext | null>(null);
   const gainNodeRef = useRef<GainNode | null>(null);
@@ -319,18 +321,21 @@ const FocusMode: React.FC<{
   const handleMouseDown = (e: React.MouseEvent) => {
     if ((e.target as HTMLElement).closest(".focus-controls")) return;
     setIsDragging(true);
+    dragScale.current = getBodyZoomScale();
+    const scale = dragScale.current;
     setDragOffset({
-      x: e.clientX - position.x,
-      y: e.clientY - position.y,
+      x: e.clientX / scale - position.x,
+      y: e.clientY / scale - position.y,
     });
   };
 
   useEffect(() => {
     const handleMouseMove = (e: MouseEvent) => {
       if (isDragging) {
+        const scale = dragScale.current || 1;
         setPosition({
-          x: e.clientX - dragOffset.x,
-          y: e.clientY - dragOffset.y,
+          x: e.clientX / scale - dragOffset.x,
+          y: e.clientY / scale - dragOffset.y,
         });
       }
     };

--- a/src/components/settings/Settings.tsx
+++ b/src/components/settings/Settings.tsx
@@ -22,6 +22,7 @@ import Changelog from "./Changelog/Changelog";
 import Data from "./Data/Data";
 import WeatherSettings from "./Weather/WeatherSettings";
 import { AppContext } from "../../context/provider";
+import { getBodyZoomScale } from "../../utils/zoom";
 
 export const SETTINGS_MENU = [
   {
@@ -97,14 +98,21 @@ export default function Settings({
   const modalRef = useRef<HTMLDivElement>(null);
   const isDragging = useRef(false);
   const offset = useRef({ x: 0, y: 0 });
+  const dragScale = useRef(1);
 
   const handleMouseDown = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
     if (!modalRef.current) return;
 
     isDragging.current = true;
+    dragScale.current = getBodyZoomScale();
+    const scale = dragScale.current;
     offset.current = {
-      x: e.clientX - modalRef.current.getBoundingClientRect().left,
-      y: e.clientY - modalRef.current.getBoundingClientRect().top,
+      x:
+        e.clientX / scale -
+        modalRef.current.getBoundingClientRect().left / scale,
+      y:
+        e.clientY / scale -
+        modalRef.current.getBoundingClientRect().top / scale,
     };
 
     document.addEventListener("mousemove", handleMouseMove);
@@ -113,10 +121,11 @@ export default function Settings({
 
   const handleMouseMove = (e: MouseEvent) => {
     if (!isDragging.current) return;
+    const scale = dragScale.current || 1;
 
     setPosition({
-      x: `${e.clientX - offset.current.x}px`,
-      y: `${e.clientY - offset.current.y}px`,
+      x: `${e.clientX / scale - offset.current.x}px`,
+      y: `${e.clientY / scale - offset.current.y}px`,
     });
   };
 

--- a/src/components/sticky-notes/StickyNotes.tsx
+++ b/src/components/sticky-notes/StickyNotes.tsx
@@ -9,6 +9,7 @@ import {
   mergeNotes,
   listenForSyncChanges,
 } from "../../utils/stickyNotesSync";
+import { getBodyZoomScale } from "../../utils/zoom";
 
 const STICKY_NOTES_KEY = "macnewtab_sticky_notes";
 
@@ -39,6 +40,7 @@ const StickyNotes: React.FC = memo(() => {
   const [notes, setNotes] = useState<Note[]>([]);
   const [draggedNote, setDraggedNote] = useState<string | null>(null);
   const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 });
+  const dragScale = useRef(1);
   const containerRef = useRef<HTMLDivElement>(null);
   const { locale, enableStickyNotesSync } = useContext(AppContext);
 
@@ -196,21 +198,26 @@ const StickyNotes: React.FC = memo(() => {
     if (!note) return;
 
     setDraggedNote(noteId);
+    dragScale.current = getBodyZoomScale();
+    const scale = dragScale.current;
     setDragOffset({
-      x: e.clientX - note.x,
-      y: e.clientY - note.y,
+      x: e.clientX / scale - note.x,
+      y: e.clientY / scale - note.y,
     });
   };
 
   const handleMouseMove = (e: MouseEvent) => {
     if (!draggedNote) return;
+    const scale = dragScale.current || 1;
+    const scaledX = e.clientX / scale;
+    const scaledY = e.clientY / scale;
 
     const updatedNotes = notes.map((note) =>
       note.id === draggedNote
         ? {
             ...note,
-            x: e.clientX - dragOffset.x,
-            y: e.clientY - dragOffset.y,
+            x: scaledX - dragOffset.x,
+            y: scaledY - dragOffset.y,
           }
         : note,
     );

--- a/src/components/todo/Todo.tsx
+++ b/src/components/todo/Todo.tsx
@@ -7,6 +7,7 @@ import linkify from "../../utils/linkify";
 import Translation from "../../locale/Translation";
 import { translation } from "../../locale/languages";
 import { arrayMove, List } from "react-movable";
+import { getBodyZoomScale } from "../../utils/zoom";
 
 export default function TodoDialog({
   open,
@@ -32,6 +33,7 @@ export default function TodoDialog({
   const [position, setPosition] = useState({ x: "unset", y: "unset" });
   const isDragging = useRef(false);
   const offset = useRef({ x: 0, y: 0 });
+  const dragScale = useRef(1);
 
   useEffect(() => {
     if (open) {
@@ -81,9 +83,15 @@ export default function TodoDialog({
     if (!modalRef.current) return;
 
     isDragging.current = true;
+    dragScale.current = getBodyZoomScale();
+    const scale = dragScale.current;
     offset.current = {
-      x: e.clientX - modalRef.current.getBoundingClientRect().left,
-      y: e.clientY - modalRef.current.getBoundingClientRect().top,
+      x:
+        e.clientX / scale -
+        modalRef.current.getBoundingClientRect().left / scale,
+      y:
+        e.clientY / scale -
+        modalRef.current.getBoundingClientRect().top / scale,
     };
 
     document.addEventListener("mousemove", handleMouseMove);
@@ -92,10 +100,11 @@ export default function TodoDialog({
 
   const handleMouseMove = (e: MouseEvent) => {
     if (!isDragging.current) return;
+    const scale = dragScale.current || 1;
 
     setPosition({
-      x: `${e.clientX - offset.current.x}px`,
-      y: `${e.clientY - offset.current.y}px`,
+      x: `${e.clientX / scale - offset.current.x}px`,
+      y: `${e.clientY / scale - offset.current.y}px`,
     });
   };
 

--- a/src/utils/zoom.ts
+++ b/src/utils/zoom.ts
@@ -1,0 +1,17 @@
+export const getBodyZoomScale = (): number => {
+  if (typeof window === "undefined" || !document?.body) return 1;
+  const zoomValue = (
+    window.getComputedStyle(document.body) as CSSStyleDeclaration & {
+      zoom?: string;
+    }
+  ).zoom;
+  if (!zoomValue || zoomValue === "normal") return 1;
+
+  if (zoomValue.endsWith("%")) {
+    const percent = parseFloat(zoomValue);
+    return Number.isFinite(percent) ? percent / 100 : 1;
+  }
+
+  const scale = parseFloat(zoomValue);
+  return Number.isFinite(scale) && scale > 0 ? scale : 1;
+};


### PR DESCRIPTION
Fixes #20.

**The Bug**  
Dragging the Settings panel, Todo modal, Sticky Notes, and Focus Mode window becomes offset from the cursor on small screens.

**The Cause**  
The drag handlers use raw `clientX`/`clientY` coordinates while the UI is scaled with CSS `zoom`. This makes pointer coordinates and element positions exist in different coordinate spaces.

**The Fix**  
Added a `getBodyZoomScale()` helper and normalized pointer coordinates by the current `body` zoom during drag start and movement in Settings, Todo, Sticky Notes, and Focus Mode. 

**Testing** 
Tested locally (drag settings/todo/sticky/focus at <816px zoom)