### PR TITLE
fix: prevent calendar and searchEngineSwitcher from rerendering every second

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, useContext, useEffect, useMemo, useState } from "react";
+import { CSSProperties, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import "./App.css";
 import Clock1 from "./widgets/clock-1/Clock1";
 import Clock2 from "./widgets/clock-2/Clock2";
@@ -24,6 +24,9 @@ import Battery from "./widgets/battery/Battery";
 const App = function App() {
   const [searchEngine, setSearchEngine] = useState("");
   const [date, setDate] = useState(new Date());
+  const [time, setTime] = useState(new Date());
+
+
 
   const {
     theme,
@@ -51,11 +54,18 @@ const App = function App() {
 
   useEffect(() => {
     if (showClockAndCalendar) {
-      const intervalRef = setInterval(() => {
-        setDate(new Date());
+      const interval = setInterval(() => {
+        const now = new Date();
+        setTime(now);
+        const currentDateStr = now.toDateString();
+        setDate(prev => {
+          if (prev.toDateString() !== currentDateStr) {
+            return now;
+          }
+          return prev;
+        });
       }, 1000);
-
-      return () => clearInterval(intervalRef);
+      return () => clearInterval(interval);
     }
   }, [showClockAndCalendar]);
 
@@ -71,10 +81,10 @@ const App = function App() {
     }
   }, []);
 
-  const handleSearchEngineChange = (val: string) => {
+  const handleSearchEngineChange = useCallback((val: string) => {
     localStorage.setItem(SEARCH_ENGINE_LOCAL_STORAGE_KEY, val);
     setSearchEngine(val);
-  };
+  }, []);
 
   const bgStyle: CSSProperties & Record<string, string> = useMemo(
     () => ({
@@ -138,7 +148,7 @@ const App = function App() {
       >
         {showClockAndCalendar && (
           <div className="section-1">
-            {useAnalogClock2 ? <Clock2 date={date} /> : <Clock1 date={date} />}
+            {useAnalogClock2 ? <Clock2 date={time} /> : <Clock1 date={time} />}
             {showMonthView ? (
               <Calendar date={date} />
             ) : (

--- a/src/widgets/calendar/Calendar.tsx
+++ b/src/widgets/calendar/Calendar.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useMemo, useState } from "react";
+import { useContext, useEffect, useMemo, useState, memo } from "react";
 import "./Calendar.css";
 import { translation } from "../../locale/languages";
 import { AppContext } from "../../context/provider";
@@ -34,7 +34,7 @@ function generateDateArray(year: number, month: number) {
   return resultArray;
 }
 
-export default function Calendar({ date }: { date: Date }) {
+export default memo(function Calendar({ date }: { date: Date }) {
   const [weeks, setWeeks] = useState<string[]>([]);
   const { locale, showGoogleCalendar, calendarEvents } = useContext(AppContext);
 
@@ -125,4 +125,4 @@ export default function Calendar({ date }: { date: Date }) {
       </div>
     </div>
   );
-}
+});

--- a/src/widgets/day-calendar/Calendar1.tsx
+++ b/src/widgets/day-calendar/Calendar1.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo } from "react";
+import { useContext, useMemo, memo } from "react";
 import "./Calendar1.css";
 import { translation } from "../../locale/languages";
 import { AppContext } from "../../context/provider";
@@ -18,7 +18,7 @@ const getWeekName = (date: Date): keyof (typeof translation)["en"] => {
     .toLowerCase() as keyof (typeof translation)["en"];
 };
 
-export default function Calendar1({ date }: { date: Date }) {
+export default memo(function Calendar1({ date }: { date: Date }) {
   const { locale, showGoogleCalendar, calendarEvents } = useContext(AppContext);
 
   const eventGroup = useMemo(() => {
@@ -68,4 +68,4 @@ export default function Calendar1({ date }: { date: Date }) {
       </div>
     </div>
   );
-}
+});


### PR DESCRIPTION
## Summary

### The Bug
The calendar components and search engine switcher were re-rendering every second unnecessarily.
### The Cause
1. `App.tsx` had a single `date` state that was being updated every second via `setInterval`, and this state was passed to both clock and calendar components
2. Calendar components were not memoized, so they re-rendered on every parent re-render
3. `handleSearchEngineChange` was not memoized, causing unstable function references

### The Fix
1. Split state into `time` (updated every second for clocks) and `date` (only updated on day transitions)
2. Wrapped `Calendar` and `Calendar1` with `React.memo` to skip re-renders when props haven't changed
3. Wrapped `handleSearchEngineChange` with `useCallback` for a stable function reference

### Before

![before](https://github.com/user-attachments/assets/3546d609-9a8d-4a0d-8268-005b9d6b034e)

### After 
![after](https://github.com/user-attachments/assets/bebc019f-1068-4877-be09-7c6e63d5eeef)




